### PR TITLE
Bugfix options reference error

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 var fs = require('fs-extra'),
   path = require('path'),
   cwd = process.cwd(),
-  noop = function() {};
+  noop = function () {};
 
 /**
  * FileStore constructor.
@@ -16,8 +16,9 @@ var fs = require('fs-extra'),
  * @api public
  */
 
-function FileStore(options) {
-  options = options || {};
+function FileStore(_options) {
+
+  var options = _options || {};
 
   var self = this;
   self.path = options.path || path.join(cwd, 'tmp');
@@ -32,7 +33,7 @@ function FileStore(options) {
 
   self.cache = {};
 
-  cacheFiles.forEach(function(file) {
+  cacheFiles.forEach(function (file) {
 
     file = file.replace('.json', '').replace('_', ':');
 
@@ -41,6 +42,7 @@ function FileStore(options) {
   });
 
 }
+
 
 /**
  * Get an entry.


### PR DESCRIPTION
Just bugfixing the options error. 
Defined tests passed successfully:
cacheman-file
    √ should have main methods
    √ should store items
    √ should store zero
    √ should store false
    √ should store null
    √ should delete items
    √ should clear items
    √ should expire key (1116ms)
  8 passing (1s)
